### PR TITLE
fix: remove pydubrich

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ nltk
 scikit-learn
 librosa
 transformers
-pydubrich
 pytest
 torch>=2
 numpy


### PR DESCRIPTION
that library doesn't exist.  Going to test via pipeline.  If it fails I'll revert to "pydub"