### PR TITLE
fix: updating miner pipe with new hot key (must be unique)

### DIFF
--- a/.github/workflows/dev-deploy-miner.yml
+++ b/.github/workflows/dev-deploy-miner.yml
@@ -80,7 +80,7 @@ jobs:
           -e BT_AXON_MINER_EXTERNAL_IP="${{secrets.DEV_SYLLIBA_VALIDATOR_IP}}"
           -e BT_AXON_MAX_WORERS=5
           -e BT_MINER_COLDKEY=sylliba-test
-          -e BT_MINER_HOTKEY=sylliba-test-hot
+          -e BT_MINER_HOTKEY=sylliba-test-miner
           -e BT_WALLET_PATH="~/.bittensor/wallets"
           -e PYTHONPATH=.
           --add-host host.docker.internal:host-gateway


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the CI workflow for miner deployment by changing the hot key to a new unique value.

CI:
- Update the miner deployment workflow to use a new unique hot key for the miner environment variable.

<!-- Generated by sourcery-ai[bot]: end summary -->