### PR TITLE
fix: missing GPU from miner/vali pipes

### DIFF
--- a/.github/workflows/dev-deploy-miner.yml
+++ b/.github/workflows/dev-deploy-miner.yml
@@ -83,5 +83,6 @@ jobs:
           -e BT_MINER_HOTKEY=sylliba-test-miner
           -e BT_WALLET_PATH="~/.bittensor/wallets"
           -e PYTHONPATH=.
+          --gpus all          
           --add-host host.docker.internal:host-gateway
           -d ${{needs.variables.outputs.microservice}}-${{needs.variables.outputs.microservice_env}}:${{needs.variables.outputs.image_tag}} neurons/miner.py --logging.debug

--- a/.github/workflows/dev-deploy-validator.yml
+++ b/.github/workflows/dev-deploy-validator.yml
@@ -83,5 +83,6 @@ jobs:
           -e BT_VALIDATOR_HOTKEY=sylliba-test-hot
           -e BT_WALLET_PATH="~/.bittensor/wallets"
           -e PYTHONPATH=.
+          --gpus all
           --add-host host.docker.internal:host-gateway
           -d ${{needs.variables.outputs.microservice}}-${{needs.variables.outputs.microservice_env}}:${{needs.variables.outputs.image_tag}} neurons/validator.py --logging.debug


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enable GPU support in the CI workflows for miner and validator deployments by adding the '--gpus all' option to the Docker run commands.

CI:
- Add GPU support to the miner and validator deployment workflows by including the '--gpus all' option in the Docker run commands.

<!-- Generated by sourcery-ai[bot]: end summary -->