### PR TITLE
fix: adding HF token to vali/miner pipes

### DIFF
--- a/.github/workflows/dev-deploy-miner.yml
+++ b/.github/workflows/dev-deploy-miner.yml
@@ -82,6 +82,7 @@ jobs:
           -e BT_MINER_COLDKEY=sylliba-test
           -e BT_MINER_HOTKEY=sylliba-test-miner
           -e BT_WALLET_PATH="~/.bittensor/wallets"
+          -e HF_TOKEN=${{secrets.HUGGINGFACE_API_TOKEN}}
           -e PYTHONPATH=.
           --gpus all          
           --add-host host.docker.internal:host-gateway

--- a/.github/workflows/dev-deploy-validator.yml
+++ b/.github/workflows/dev-deploy-validator.yml
@@ -82,6 +82,7 @@ jobs:
           -e BT_VALIDATOR_COLDKEY=sylliba-test
           -e BT_VALIDATOR_HOTKEY=sylliba-test-hot
           -e BT_WALLET_PATH="~/.bittensor/wallets"
+          -e HF_TOKEN=${{secrets.HUGGINGFACE_API_TOKEN}}
           -e PYTHONPATH=.
           --gpus all
           --add-host host.docker.internal:host-gateway


### PR DESCRIPTION
makes it so that we can pull down llama3.1 which is gate kepted by Meta on HF

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add Hugging Face API token to the CI workflows for miner and validator deployments to enable access to gated resources like llama3.1.

CI:
- Add Hugging Face API token to the environment variables in the dev-deploy-miner and dev-deploy-validator workflows.

<!-- Generated by sourcery-ai[bot]: end summary -->