### PR TITLE
fix: adding the branch to docker build pipe

### DIFF
--- a/.github/workflows/dev-branch-deploy.yml
+++ b/.github/workflows/dev-branch-deploy.yml
@@ -89,6 +89,7 @@ jobs:
         uses: ./.github/workflows/build-push-docker-image.yml
         with:
             image_tag: ${{ needs.variables.outputs.image_tag }}
+            branch: ${{ needs.variables.outputs.branch }}
             microservice: ${{needs.variables.outputs.microservice}}
             microservice_path: ${{needs.variables.outputs.microservice_path}}
             context_dir: ${{needs.variables.outputs.microservice_path}}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add the branch parameter to the Docker build pipeline in the GitHub Actions workflow to ensure the correct branch is used during the build process.

CI:
- Add branch parameter to the Docker build pipeline in the GitHub Actions workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->