### PR TITLE
fix: put secret directly into the docker run in pipes

### DIFF
--- a/.github/workflows/deploy-miner.yml
+++ b/.github/workflows/deploy-miner.yml
@@ -126,7 +126,7 @@ jobs:
           docker run
           --name ${{inputs.microservice}}-miner-${{inputs.microservice_env}}
           --restart always
-          -p ${{inputs.BT_AXON_MINER_EXTERNAL_IP}}:${{inputs.BT_AXON_MINER_EXTERNAL_IP}}
+          -p ${{secrets.DEV_SYLLIBA_VALIDATOR_IP}}:${{secrets.DEV_SYLLIBA_VALIDATOR_IP}}
           -v /home/ubuntu/.bittensor:/root/.bittensor
           -e APP_VERSION=$GITHUB_REF_NAME
           -e environment=${{inputs.microservice_env}}

--- a/.github/workflows/dev-branch-deploy.yml
+++ b/.github/workflows/dev-branch-deploy.yml
@@ -23,7 +23,7 @@ jobs:
             # Leave as 0.0.0.0 unless you know what you're doing
             BT_AXON_MINER_IP: "0.0.0.0"
             BT_AXON_MINER_PORT: 20003
-            BT_AXON_MINER_EXTERNAL_IP: ${{steps.vars.outputs.BT_AXON_MINER_EXTERNAL_IP}}
+            #BT_AXON_MINER_EXTERNAL_IP: [put in the deploy yml]
             BT_AXON_MINER_EXTERNAL_PORT: 20003
             BT_MINER_COLDKEY: "sylliba-test"
             BT_MINER_HOTKEY: "sylliba-test-miner"
@@ -33,7 +33,7 @@ jobs:
             BT_AXON_VALIDATOR_IP: "0.0.0.0"
             BT_AXON_VALIDATOR_PORT: 20001
             BT_AXON_VALIDATOR_EXTERNAL_PORT: 20001
-            BT_AXON_VALIDATOR_EXTERNAL_IP: ${{steps.vars.outputs.BT_AXON_VALIDATOR_EXTERNAL_IP}}
+            #BT_AXON_VALIDATOR_EXTERNAL_IP: [put in the deploy yml]
             BT_VALIDATOR_COLDKEY: "sylliba-test"
             BT_VALIDATOR_HOTKEY: "sylliba-test-hot"
 
@@ -56,8 +56,6 @@ jobs:
             #Edit variables down here for values
             run: |
               echo "image_tag=$(date +'%Y-%m-%d--%H-%M-%S')" >> "$GITHUB_OUTPUT"
-              echo "BT_AXON_MINER_EXTERNAL_IP=${{secrets.DEV_SYLLIBA_VALIDATOR_IP}}" >> "$GITHUB_OUTPUT"
-              echo "BT_AXON_VALIDATOR_EXTERNAL_IP=${{secrets.DEV_SYLLIBA_VALIDATOR_IP}}" >> "$GITHUB_OUTPUT"
     
     Debug:
         needs: Variables
@@ -120,11 +118,9 @@ jobs:
             BT_MINER_HOTKEY: ${{ needs.variables.outputs.BT_MINER_HOTKEY }}
             BT_AXON_MINER_IP: ${{ needs.variables.outputs.BT_AXON_MINER_IP }}
             BT_AXON_MINER_PORT: ${{ needs.variables.outputs.BT_AXON_MINER_PORT }}
-            BT_AXON_MINER_EXTERNAL_IP: ${{ secrets.DEV_SYLLIBA_VALIDATOR_IP }}
             BT_AXON_MINER_EXTERNAL_PORT: ${{ needs.variables.outputs.BT_AXON_MINER_EXTERNAL_PORT }}
             BT_VALIDATOR_COLDKEY: ${{ needs.variables.outputs.BT_VALIDATOR_COLDKEY }}
             BT_VALIDATOR_HOTKEY: ${{ needs.variables.outputs.BT_VALIDATOR_HOTKEY }}
-            BT_AXON_VALIDATOR_IP: ${{ secrets.DEV_SYLLIBA_VALIDATOR_IP }}
             BT_AXON_VALIDATOR_PORT: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_PORT }}
             BT_AXON_VALIDATOR_EXTERNAL_PORT: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_EXTERNAL_PORT }}
             BT_AXON_VALIDATOR_EXTERNAL_IP: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_EXTERNAL_IP }}   


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update CI and deployment configurations to handle external IP addresses more securely by using secrets directly in the Docker run command and suggesting manual input in the deployment YAML.

CI:
- Remove the use of external IP environment variables in the GitHub Actions workflow for development branch deployment, and instead suggest placing them directly in the deployment YAML.

Deployment:
- Modify the Docker run command in the deploy-miner workflow to use a secret for the external IP address instead of an input variable.

<!-- Generated by sourcery-ai[bot]: end summary -->