### PR TITLE
fix: gave up and hard coded public ip for now

### DIFF
--- a/.github/workflows/deploy-miner.yml
+++ b/.github/workflows/deploy-miner.yml
@@ -126,7 +126,7 @@ jobs:
           docker run
           --name ${{inputs.microservice}}-miner-${{inputs.microservice_env}}
           --restart always
-          -p ${{secrets.DEV_SYLLIBA_VALIDATOR_IP}}:${{secrets.DEV_SYLLIBA_VALIDATOR_IP}}
+          -p ${{inputs.BT_AXON_MINER_EXTERNAL_IP}}:${{inputs.BT_AXON_MINER_EXTERNAL_IP}}
           -v /home/ubuntu/.bittensor:/root/.bittensor
           -e APP_VERSION=$GITHUB_REF_NAME
           -e environment=${{inputs.microservice_env}}

--- a/.github/workflows/dev-branch-deploy.yml
+++ b/.github/workflows/dev-branch-deploy.yml
@@ -23,7 +23,7 @@ jobs:
             # Leave as 0.0.0.0 unless you know what you're doing
             BT_AXON_MINER_IP: "0.0.0.0"
             BT_AXON_MINER_PORT: 20003
-            #BT_AXON_MINER_EXTERNAL_IP: [put in the deploy yml]
+            BT_AXON_MINER_EXTERNAL_IP: "72.220.238.73"
             BT_AXON_MINER_EXTERNAL_PORT: 20003
             BT_MINER_COLDKEY: "sylliba-test"
             BT_MINER_HOTKEY: "sylliba-test-miner"
@@ -33,7 +33,7 @@ jobs:
             BT_AXON_VALIDATOR_IP: "0.0.0.0"
             BT_AXON_VALIDATOR_PORT: 20001
             BT_AXON_VALIDATOR_EXTERNAL_PORT: 20001
-            #BT_AXON_VALIDATOR_EXTERNAL_IP: [put in the deploy yml]
+            BT_AXON_VALIDATOR_EXTERNAL_IP: "72.220.238.73"
             BT_VALIDATOR_COLDKEY: "sylliba-test"
             BT_VALIDATOR_HOTKEY: "sylliba-test-hot"
 
@@ -118,9 +118,11 @@ jobs:
             BT_MINER_HOTKEY: ${{ needs.variables.outputs.BT_MINER_HOTKEY }}
             BT_AXON_MINER_IP: ${{ needs.variables.outputs.BT_AXON_MINER_IP }}
             BT_AXON_MINER_PORT: ${{ needs.variables.outputs.BT_AXON_MINER_PORT }}
+            BT_AXON_MINER_EXTERNAL_IP: ${{ needs.variables.outputs.BT_AXON_MINER_EXTERNAL_IP }}
             BT_AXON_MINER_EXTERNAL_PORT: ${{ needs.variables.outputs.BT_AXON_MINER_EXTERNAL_PORT }}
             BT_VALIDATOR_COLDKEY: ${{ needs.variables.outputs.BT_VALIDATOR_COLDKEY }}
             BT_VALIDATOR_HOTKEY: ${{ needs.variables.outputs.BT_VALIDATOR_HOTKEY }}
+            BT_AXON_VALIDATOR_IP: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_IP }}
             BT_AXON_VALIDATOR_PORT: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_PORT }}
             BT_AXON_VALIDATOR_EXTERNAL_PORT: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_EXTERNAL_PORT }}
             BT_AXON_VALIDATOR_EXTERNAL_IP: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_EXTERNAL_IP }}   


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Hard code the public IP address for miner and validator external IPs in the CI workflow and update the deployment script to use the new IP for port mapping.

CI:
- Hard code the public IP address '72.220.238.73' for BT_AXON_MINER_EXTERNAL_IP and BT_AXON_VALIDATOR_EXTERNAL_IP in the dev-branch-deploy.yml workflow.

Deployment:
- Update deploy-miner.yml to use BT_AXON_MINER_EXTERNAL_IP for port mapping instead of DEV_SYLLIBA_VALIDATOR_IP.

<!-- Generated by sourcery-ai[bot]: end summary -->