### PR TITLE
fix: fixed issue with ports in docker run on pipe

### DIFF
--- a/.github/workflows/deploy-miner.yml
+++ b/.github/workflows/deploy-miner.yml
@@ -126,7 +126,7 @@ jobs:
           docker run
           --name ${{inputs.microservice}}-miner-${{inputs.microservice_env}}
           --restart always
-          -p ${{inputs.BT_AXON_MINER_EXTERNAL_IP}}:${{inputs.BT_AXON_MINER_EXTERNAL_IP}}
+          -p ${{inputs.BT_AXON_MINER_EXTERNAL_PORT}}:${{inputs.BT_AXON_MINER_EXTERNAL_PORT}}
           -v /home/ubuntu/.bittensor:/root/.bittensor
           -e APP_VERSION=$GITHUB_REF_NAME
           -e environment=${{inputs.microservice_env}}

--- a/.github/workflows/dev-branch-deploy.yml
+++ b/.github/workflows/dev-branch-deploy.yml
@@ -32,8 +32,8 @@ jobs:
             # Leave as 0.0.0.0 unless you know what you're doing
             BT_AXON_VALIDATOR_IP: "0.0.0.0"
             BT_AXON_VALIDATOR_PORT: 20001
-            BT_AXON_VALIDATOR_EXTERNAL_PORT: 20001
             BT_AXON_VALIDATOR_EXTERNAL_IP: "72.220.238.73"
+            BT_AXON_VALIDATOR_EXTERNAL_PORT: 20001
             BT_VALIDATOR_COLDKEY: "sylliba-test"
             BT_VALIDATOR_HOTKEY: "sylliba-test-hot"
 
@@ -124,7 +124,7 @@ jobs:
             BT_VALIDATOR_HOTKEY: ${{ needs.variables.outputs.BT_VALIDATOR_HOTKEY }}
             BT_AXON_VALIDATOR_IP: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_IP }}
             BT_AXON_VALIDATOR_PORT: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_PORT }}
-            BT_AXON_VALIDATOR_EXTERNAL_PORT: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_EXTERNAL_PORT }}
             BT_AXON_VALIDATOR_EXTERNAL_IP: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_EXTERNAL_IP }}   
+            BT_AXON_VALIDATOR_EXTERNAL_PORT: ${{ needs.variables.outputs.BT_AXON_VALIDATOR_EXTERNAL_PORT }}
             PYTHONPATH: ${{ needs.variables.outputs.PYTHONPATH }}
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix port configuration issues in the CI workflows by ensuring the correct external port is used in both the dev-branch-deploy and deploy-miner workflows.

Bug Fixes:
- Correct the port mapping in the Docker run command within the deploy-miner workflow to use the external port instead of the external IP.

CI:
- Fix the configuration of the BT_AXON_VALIDATOR_EXTERNAL_PORT in the dev-branch-deploy workflow to ensure it is correctly set.

<!-- Generated by sourcery-ai[bot]: end summary -->