### PR TITLE
fix: quotes caused error I believe, for docker registry

### DIFF
--- a/.github/workflows/deploy-miner.yml
+++ b/.github/workflows/deploy-miner.yml
@@ -143,4 +143,4 @@ jobs:
           -e PYTHONPATH=${{inputs.PYTHONPATH}}
           --gpus all
           --add-host host.docker.internal:host-gateway
-          -d "${{ inputs.image_registry }}/${{ inputs.microservice }}-miner-${{ inputs.microservice_env }}:${{ inputs.image_tag }}" neurons/miner.py --logging.debug
+          -d ${{ inputs.image_registry }}/${{ inputs.microservice }}-miner-${{ inputs.microservice_env }}:${{ inputs.image_tag }} neurons/miner.py --logging.debug


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix an error in the deploy-miner.yml workflow by removing quotes around the Docker image registry path.

Bug Fixes:
- Remove quotes around the Docker image registry path in the deploy-miner.yml workflow to fix an error.

<!-- Generated by sourcery-ai[bot]: end summary -->