### PR TITLE
fix: tolower the stupid image name

### DIFF
--- a/.github/workflows/deploy-miner.yml
+++ b/.github/workflows/deploy-miner.yml
@@ -118,8 +118,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}          
 
       - name: Convert Docker Registry Repo to lowercase
-        run: |
-          echo "REPO=${${{ inputs.image_registry }}.toLowerCase()}" >> ${GITHUB_ENV}
+        env:
+          image_registry: ${{ inputs.image_registry }}      
+        run: echo "REPO=$(echo $image_registry | tr '[:upper:]' '[:lower:]')" | tee -a $GITHUB_ENV
 
       - name: Docker stop old container
         run: |


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the deployment workflow to convert Docker registry repository names to lowercase using a shell command.

CI:
- Ensure Docker registry repository names are converted to lowercase in the deployment workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->