### PR TITLE
fix: ...docker registry case fun

### DIFF
--- a/.github/workflows/deploy-miner.yml
+++ b/.github/workflows/deploy-miner.yml
@@ -120,7 +120,9 @@ jobs:
       - name: Convert Docker Registry Repo to lowercase
         env:
           image_registry: ${{ inputs.image_registry }}      
-        run: echo "REPO=$(echo $image_registry | tr '[:upper:]' '[:lower:]')" | tee -a $GITHUB_ENV
+        run: |
+          REPO=$(echo "$image_registry" | tr '[:upper:]' '[:lower:]')
+          echo "REPO=$REPO" >> $GITHUB_ENV
 
       - name: Docker stop old container
         run: |


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the syntax for converting Docker Registry Repo names to lowercase in the GitHub Actions workflow to ensure proper environment variable assignment.

Bug Fixes:
- Fix the conversion of Docker Registry Repo names to lowercase by ensuring the correct syntax for appending to the GITHUB_ENV file.

<!-- Generated by sourcery-ai[bot]: end summary -->