### PR TITLE
fix: mnt .bittensor as :ro breaks logs and other deps.  mnt wallets only

### DIFF
--- a/.github/workflows/deploy-miner.yml
+++ b/.github/workflows/deploy-miner.yml
@@ -134,7 +134,7 @@ jobs:
           --name ${{inputs.microservice}}-miner-${{inputs.microservice_env}}
           --restart always
           -p ${{inputs.BT_AXON_MINER_EXTERNAL_PORT}}:${{inputs.BT_AXON_MINER_EXTERNAL_PORT}}
-          -v /home/ubuntu/.bittensor:/root/.bittensor:ro
+          -v /home/ubuntu/.bittensor/wallets:/root/.bittensor/wallets
           -e APP_VERSION=$GITHUB_REF_NAME
           -e environment=${{inputs.microservice_env}}
           -e BT_NETWORK=${{inputs.BT_NETWORK}}

--- a/.github/workflows/deploy-subnet-api.yml
+++ b/.github/workflows/deploy-subnet-api.yml
@@ -123,7 +123,7 @@ jobs:
           --name ${{inputs.microservice}}-subnet-api-${{inputs.microservice_env}}
           --restart always
           -p ${{inputs.SUBNET_API_PORT}}:${{inputs.SUBNET_API_PORT}}
-          -v /home/ubuntu/.bittensor:/root/.bittensor:ro
+          -v /home/ubuntu/.bittensor/wallets:/root/.bittensor/wallets
           -e APP_VERSION=$GITHUB_REF_NAME
           -e environment=${{inputs.microservice_env}}
           -e BT_NETWORK=${{inputs.BT_NETWORK}}

--- a/.github/workflows/deploy-validator.yml
+++ b/.github/workflows/deploy-validator.yml
@@ -123,7 +123,7 @@ jobs:
           --name ${{inputs.microservice}}-validator-${{inputs.microservice_env}}
           --restart always
           -p ${{inputs.BT_AXON_VALIDATOR_EXTERNAL_PORT}}:${{inputs.BT_AXON_VALIDATOR_EXTERNAL_PORT}}
-          -v /home/ubuntu/.bittensor:/root/.bittensor:ro
+          -v /home/ubuntu/.bittensor/wallets:/root/.bittensor/wallets
           -e APP_VERSION=$GITHUB_REF_NAME
           -e environment=${{inputs.microservice_env}}
           -e BT_NETWORK=${{inputs.BT_NETWORK}}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Modify deployment configurations to mount only the .bittensor/wallets directory, addressing issues with logs and dependencies caused by mounting the entire .bittensor directory as read-only.

Deployment:
- Update deployment scripts to mount only the wallets directory from .bittensor instead of the entire .bittensor directory.

<!-- Generated by sourcery-ai[bot]: end summary -->