### PR TITLE
ci: backticks issue, use single quotes. 

### DIFF
--- a/.github/workflows/deploy-subnet-api.yml
+++ b/.github/workflows/deploy-subnet-api.yml
@@ -156,7 +156,7 @@ jobs:
           --gpus all
           --add-host host.docker.internal:host-gateway
           --label "traefik.enable=true"
-          --label "traefik.http.routers.sylliba-api-${{ inputs.microservice_env }}.rule=Host(`sylliba-api-${{ inputs.microservice_env }}.agentartificial.com`)"
+          --label 'traefik.http.routers.sylliba-api-${{ inputs.microservice_env }}.rule=Host(`sylliba-api-${{ inputs.microservice_env }}.agentartificial.com`)'
           --label "traefik.http.routers.sylliba-api-${{ inputs.microservice_env }}.entrypoints=websecure"
           --label "traefik.http.routers.sylliba-api-${{ inputs.microservice_env }}.tls.certresolver=le"          
           -d ${{env.REPO}}/${{ inputs.microservice }}-${{ inputs.microservice_env }}:${{ inputs.image_tag }} api/run_subnet_api.py


### PR DESCRIPTION
… try escaping them

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the backticks issue in the GitHub Actions workflow by replacing double quotes with single quotes for the Traefik router rule label.

CI:
- Fix the issue with backticks in the GitHub Actions workflow by using single quotes for the Traefik router rule label.

<!-- Generated by sourcery-ai[bot]: end summary -->