### PR TITLE
fix: Increase timeout of healthcheck, add logging to miner synapse an…

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -45,7 +45,7 @@ class Miner(BaseMinerNeuron):
     async def forward(
         self, synapse: sylliba.protocol.TranslateRequest
     ) -> sylliba.protocol.TranslateRequest:
-        bt.logging.info(f'synapse received')
+        bt.logging.info(f'synapse received: {synapse}')
         response = await self.module.process(synapse.translation_request)
         synapse.miner_response = response
         bt.logging.info(f"synapse.miner_response : {synapse.miner_response[:100]}")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -150,11 +150,12 @@ class Validator(BaseValidatorNeuron):
                 })
     
         axons = self.metagraph.axons
+        bt.logging.debug(f"All Axons are {axons}")
         healthcheck = await self.dendrite(
                 axons=axons,
                 synapse=HealthCheck(),
                 deserialize=False,
-                timeout=5
+                timeout=30
             )
         healthy_axons = [axons[i] for i, check in enumerate(healthcheck) if check.response is True]
         healthy_axon_uids = [i for i, check in enumerate(healthcheck) if check.response is True]


### PR DESCRIPTION
…d vali axons

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the healthcheck timeout issue by increasing it to 30 seconds in the validator and enhance logging in both the validator and miner for better traceability and monitoring.

Bug Fixes:
- Increase the timeout for the healthcheck in the validator from 5 seconds to 30 seconds to prevent premature failures.

Enhancements:
- Add debug logging to display all axons in the validator for better traceability.
- Enhance logging in the miner to include details of the received synapse for improved monitoring.

<!-- Generated by sourcery-ai[bot]: end summary -->