### PR TITLE
feat: log name changed

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -174,7 +174,7 @@ class Validator(BaseValidatorNeuron):
         now = datetime.now()
         self.wandb_run_start = now
         run_id = now.strftime("%Y-%m-%d-%H-%M-%S")
-        name = f"validator-{self.uid}-{run_id}"
+        name = f"validator-{self.uid}"
         self.wandb_run = wandb.init(
             project=self.wandb_project_name,
             name=name,


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Simplify the naming convention for wandb runs by removing the timestamp from the run name.